### PR TITLE
moved react and react-dom to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/Wildhoney/ReactShadow/issues"
   },
   "homepage": "https://github.com/Wildhoney/ReactShadow",
-  "dependencies": {
+  "peerDependencies": {
     "react": ">=0.14.7 <=15.x",
     "react-dom": ">=0.14.7 <=15.x"
   },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "nyc": "~10.2.0",
     "prop-types": "~15.5.8",
     "ramda": "^0.22.1",
+    "react": ">=0.14.7 <=15.x",
+    "react-dom": ">=0.14.7 <=15.x",
     "react-addons-test-utils": "^15.3.1",
     "react-document-title": "~2.0.3",
     "react-redux": "~5.0.3",


### PR DESCRIPTION
Having `react` and `react-dom` as hard dependencies can create (and does for our project) conflicts as these can resolve to different versions which will then be bundled. This can easily be avoided by declaring them as `peerDependencies`. 