### PR TITLE
Secure componentWillUnmount

### DIFF
--- a/src/react-shadow.js
+++ b/src/react-shadow.js
@@ -204,7 +204,9 @@ export const withContext = contextTypes => {
          * @return {void}
          */
         componentWillUnmount() {
-            unmountComponentAtNode(this.state.root);
+            if (this.state.root) {
+                unmountComponentAtNode(this.state.root);
+            }
         }
 
         /**


### PR DESCRIPTION
On wide app, when `componentWillUnmount` is call ( async) `this.state.root` can be undefined because it refers to a DOM element no longer in page, then  calling `unmountComponentAtNode` with something which is not a DOM node generate error in dev mode. 

Prevent this error by checking the value of `this.state.root` before calling `unmountComponentAtNode`