### PR TITLE
Add createProxy to support overriding target for polyfills

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,14 +59,18 @@ function createComponent(options) {
 
 const components = new Map();
 
-export default new Proxy(
-    {},
-    {
-        get: function get(_, name) {
-            const tag = decamelize(name, { separator: '-' });
-            if (!components.has(tag))
-                components.set(tag, createComponent({ tag }));
-            return components.get(tag);
+export function createProxy(target = {}) {
+    return new Proxy(
+        target,
+        {
+            get: function get(_, name) {
+                const tag = decamelize(name, { separator: '-' });
+                if (!components.has(tag))
+                    components.set(tag, createComponent({ tag }));
+                return components.get(tag);
+            },
         },
-    },
-);
+    );
+}
+
+export default createProxy();


### PR DESCRIPTION
When polyfilling Proxy, there's a caveat that the target must define proxied properties in order for the polyfill to work properly.

To support this, we can export a function that creates the root Proxy and allow users to create their own Proxy instance with pre-defined properties. With a Proxy and Shadow DOM polyfill, this allows the library to be used on IE11.

```jsx
import root from 'react-shadow';

ReactDOM.render(
  <root.div>
    <h1>Doesn't work :(</h1>
  </root.div>, 
  document.querySelector('#root')
);
```
With [proxy-polyfill](https://github.com/GoogleChrome/proxy-polyfill) and [webcomponentsjs](https://github.com/webcomponents/webcomponentsjs):
```jsx
import { createProxy } from 'react-shadow';

const root = createProxy({ 
  div: undefined // pre-define all properties we want to access
});

ReactDOM.render(
  <root.div>
    <h1>Works in IE11! :)</h1>
  </root.div>, 
  document.querySelector('#root')
);
```