### PR TITLE
Provide ShadowRoot to child components via Context

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "module": "dist/react-shadow.esm.js",
   "repository": "git@github.com:Wildhoney/ReactShadow.git",
   "author": "Adam Timberlake <adam.timberlake@gmail.com>",
+  "contributors": [
+    "Chris Trevino <darthtrevino@gmail.com>"
+  ],
   "license": "MIT",
   "scripts": {
     "build": "rollup -c && webpack --config example/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-shadow",
+  "name": "@darthtrevino/react-shadow",
   "version": "17.5.0",
   "description": "Utilise Shadow DOM in React with all the benefits of style encapsulation.",
   "main": "dist/react-shadow.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@darthtrevino/react-shadow",
+  "name": "react-shadow",
   "version": "17.5.0",
   "description": "Utilise Shadow DOM in React with all the benefits of style encapsulation.",
   "main": "dist/react-shadow.cjs.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,23 @@
-import React, { useState, useEffect, forwardRef } from 'react';
+import React, {
+    useState,
+    useEffect,
+    forwardRef,
+    createContext,
+    useContext,
+} from 'react';
 import { useEnsuredForwardedRef } from 'react-use';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { decamelize } from 'humps';
+
+const ShadowRootContext = createContext(null);
+
+/**
+ * Allows clients to use the shadow-root
+ */
+export function useShadowRoot() {
+    return useContext(ShadowRootContext)
+}
 
 function Noop({ children }) {
     return children;
@@ -72,11 +87,13 @@ function createTag(options) {
             return (
                 <options.tag key={key} ref={node} {...props}>
                     {root && (
-                        <Wrapper target={root}>
-                            <ShadowContent root={root}>
-                                {children}
-                            </ShadowContent>
-                        </Wrapper>
+                        <ShadowRootContext.Provider root={root}>
+                            <Wrapper target={root}>
+                                <ShadowContent root={root}>
+                                    {children}
+                                </ShadowContent>
+                            </Wrapper>
+                        </ShadowRootContext.Provider>
                     )}
                 </options.tag>
             );

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ function createTag(options) {
             return (
                 <options.tag key={key} ref={node} {...props}>
                     {root && (
-                        <ShadowRootContext.Provider root={root}>
+                        <ShadowRootContext.Provider value={root}>
                             <Wrapper target={root}>
                                 <ShadowContent root={root}>
                                     {children}

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { mount } from 'enzyme';
 import * as R from 'ramda';
 import sinon from 'sinon';
-import root from './';
+import root, { useShadowRoot } from './';
 
 test('It should be able to create the shadow boundary;', t => {
     const wrapper = mount(<root.div>Hello Adam!</root.div>);
@@ -102,6 +102,22 @@ test('It should be able to apply styles to the shadow boundary components;', t =
     );
     const node = wrapper.getDOMNode().shadowRoot.querySelector('style');
     t.is(node.innerHTML, '* { border: 1px solid red; }');
+});
+
+
+
+test('It should be able to access the shadow-root from client components;', t => {
+    const Inner = () => {
+        const shadowRoot = useShadowRoot()
+        console.log("mounted", shadowRoot)
+        t.true(!!shadowRoot, "expected shadowroot to be truthy")
+        return <>Hello!/</>
+    }
+    mount(
+        <root.div>
+            <Inner />
+        </root.div>,
+    );
 });
 
 test('It should be able re-render the component tree from the event handlers;', t => {


### PR DESCRIPTION
By using a new export, `useShadowRoot`, clients can access the shadowRoot instance, which contains various CSS selector APIs.