### PR TITLE
Move emotion ssr capabilities out of core.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "build": "yarn run build-core && yarn run build-emotion && yarn run build-styled-components && yarn run build-material-ui && next build ./example",
         "build-core": "rollup -c --environment input:index,output:react-shadow",
         "build-emotion": "rollup -c --environment input:emotion/index,output:emotion",
+        "build-emotion-ssr": "rollup -c --environment input:emotion-ssr/index,output:emotion-ssr",
         "build-styled-components": "rollup -c --environment input:styled-components/index,output:styled-components",
         "build-material-ui": "rollup -c --environment input:material-ui/index,output:material-ui",
         "test": "yarn spec && yarn lint",
@@ -25,7 +26,7 @@
         "start": "next ./example -p ${PORT:-3000}",
         "deploy": "now",
         "prepublishOnly": "mv dist/* ./",
-        "postpublish": "mv {react-shadow,emotion,styled-components,material-ui}{.js,.js.map,.esm.js,.esm.js.map} ./dist"
+        "postpublish": "mv {react-shadow,emotion,emotion-ssr,styled-components,material-ui}{.js,.js.map,.esm.js,.esm.js.map} ./dist"
     },
     "husky": {
         "hooks": {

--- a/src/emotion-ssr/index.js
+++ b/src/emotion-ssr/index.js
@@ -1,11 +1,17 @@
 import React from 'react';
+import { renderToString } from 'react-dom/server';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
+import { renderStylesToString } from '@emotion/server';
 import { createProxy } from '../';
 
 const cache = new WeakMap();
 
-export default createProxy({}, 'emotion', ({ root, children }) => {
+export function getStyles(children) {
+    return renderStylesToString(renderToString(<>{children}</>));
+}
+
+export default createProxy({}, 'emotion', ({ ssr, root, children }) => {
     const options =
         cache.get(root) ||
         (() => {
@@ -16,6 +22,14 @@ export default createProxy({}, 'emotion', ({ root, children }) => {
             cache.set(root, options);
             return options;
         })();
+
+    if (ssr)
+        return (
+            <>
+                <style type="text/css">{getStyles(children)}</style>
+                {children}
+            </>
+        );
 
     return (
         <CacheProvider value={options}>

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -6,6 +6,7 @@ import * as R from 'ramda';
 import sinon from 'sinon';
 import rootSC from './styled-components';
 import rootE from './emotion';
+import rootESSR from './emotion-ssr';
 import root, { useShadowRoot } from './';
 
 test('It should be able to create the shadow boundary;', (t) => {
@@ -173,6 +174,24 @@ test('It should be able to encapsulate emotion styles in the boundary;', (t) => 
         <rootE.sayHello>
             <Name>Hello Adam!</Name>
         </rootE.sayHello>,
+    );
+    t.truthy(wrapper.getDOMNode().shadowRoot);
+    t.is(wrapper.getDOMNode().nodeName.toLowerCase(), 'say-hello');
+    t.is(wrapper.find(Name).text(), 'Hello Adam!');
+
+    const styles = wrapper.getDOMNode().shadowRoot.querySelector('style');
+    t.falsy(styles);
+});
+
+test('SSR: It should be able to encapsulate emotion styles in the boundary;', (t) => {
+    const Name = styled.section`
+        color: rebeccapurple;
+    `;
+
+    const wrapper = mount(
+        <rootESSR.sayHello>
+            <Name>Hello Adam!</Name>
+        </rootESSR.sayHello>,
     );
     t.truthy(wrapper.getDOMNode().shadowRoot);
     t.is(wrapper.getDOMNode().nodeName.toLowerCase(), 'say-hello');


### PR DESCRIPTION
Addresses [this issue](https://github.com/Wildhoney/ReactShadow/issues/88), and allows using emotion when not working with SSR.

I'm sure there's likely another way you'd like to do this @Wildhoney , but I figured I'd start the conversation with this PR.