### PR TITLE
fix: change global to globalThis

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,5 +15,8 @@
         "react": {
             "version": "detect"
         }
+    },
+    "env": {
+        "es2020": true
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ You may pass any props you like to the `root.*` component which will be applied 
 ShadowRoot.propTypes = {
     mode: PropTypes.oneOf(['open', 'closed']),
     delegatesFocus: PropTypes.bool,
-    styleSheets: PropTypes.arrayOf(PropTypes.instanceOf(global.CSSStyleSheet)),
+    styleSheets: PropTypes.arrayOf(
+        PropTypes.instanceOf(globalThis.CSSStyleSheet),
+    ),
     children: PropTypes.node,
 };
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -83,7 +83,7 @@ export default function create(options) {
         mode: PropTypes.oneOf(['open', 'closed']),
         delegatesFocus: PropTypes.bool,
         styleSheets: PropTypes.arrayOf(
-            PropTypes.instanceOf(global.CSSStyleSheet),
+            PropTypes.instanceOf(globalThis.CSSStyleSheet),
         ),
         ssr: PropTypes.bool,
         children: PropTypes.node,


### PR DESCRIPTION
Hello everyone 👋 

I think i have found a bug with the application if i'm not using any tool like Webpack.
With Webpack we can use the application normaly and the "global" under it will work :

```js
styleSheets: PropTypes.arrayOf(
    PropTypes.instanceOf(global),
)
```

But, if i'm using something else, like [vite](https://vitejs.dev/) for example we cannot use the "global" variables ...
So, i think we can use "globalThis" instead. It supported in most browser you can check the [caniuse](https://caniuse.com/?search=globalThis) if wanted.

globalThis is supported the same as [shadow dom](https://caniuse.com/?search=shadow%20dom).

Hope this will help you :)
If you have any question, suggestion and other you can send to me a message here 👋 