### PR TITLE
chore: improve typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,24 @@ declare module 'react-shadow' {
         >;
     };
 
+    type CreateProxyFn = (
+        target: unknown,
+        id: string,
+        render: ({
+            children,
+        }: {
+            children: React.ReactNode;
+            ssr: boolean;
+            root: ShadowRoot;
+        }) => React.ReactNode,
+    ) => Root;
+
+    const createProxy: CreateProxyFn;
     const ReactShadowRoot: Root;
+    const useShadowRoot: () => ShadowRoot;
 
     export default ReactShadowRoot;
+
+    export { createProxy, useShadowRoot };
+    export type { Root };
 }


### PR DESCRIPTION
This PR:
- add types for `useShadowRoot` & `createProxy` (required as you can't use existing exports)
  https://github.com/Wildhoney/ReactShadow/blob/a8a6ecdd4c8279eb38a07cb4805b5e5ffb41f3ba/src/index.js#L8-L12
- exports `Root` type (can be optional)