### PR TITLE
[Fix- #155 ] shadowroot to shadowrootmode in DSD

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -72,7 +72,7 @@ export default function create(options) {
                         {(root || ssr) && (
                             <utils.Context.Provider value={root}>
                                 {ssr ? (
-                                    <Template shadowrootmode={mode}>
+                                    <Template shadowroot={mode} shadowrootmode={mode}>
                                         {options.render({
                                             root,
                                             ssr,

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -72,7 +72,7 @@ export default function create(options) {
                         {(root || ssr) && (
                             <utils.Context.Provider value={root}>
                                 {ssr ? (
-                                    <Template shadowroot="open">
+                                    <Template shadowrootmode={mode}>
                                         {options.render({
                                             root,
                                             ssr,


### PR DESCRIPTION
Fix for https://github.com/Wildhoney/ReactShadow/issues/155

In DSD shadowroot has been depricated and replaced with shadowrootmode